### PR TITLE
fix(biome-lsp): guard against stale ctx in status indicator setInterval

### DIFF
--- a/packages/biome-lsp/extensions/index.ts
+++ b/packages/biome-lsp/extensions/index.ts
@@ -587,8 +587,17 @@ export default function (pi: ExtensionAPI) {
 	// -------------------------------------------------------------------------
 
 	pi.on("session_start", async (_event, ctx) => {
+		let active = true;
+
 		const update = () => {
-			ctx.ui.setStatus("biome", daemon?.ready ? "biome ✓" : undefined);
+			if (!active) return;
+			try {
+				ctx.ui.setStatus("biome", daemon?.ready ? "biome ✓" : undefined);
+			} catch {
+				// Context is stale after session replacement — stop polling
+				active = false;
+				clearInterval(interval);
+			}
 		};
 
 		// Initial + periodic update
@@ -596,8 +605,10 @@ export default function (pi: ExtensionAPI) {
 		const interval = setInterval(update, 10_000);
 
 		// Cleanup on shutdown
-		pi.on("session_shutdown", () => {
+		const onShutdown = () => {
+			active = false;
 			clearInterval(interval);
-		});
+		};
+		pi.on("session_shutdown", onShutdown);
 	});
 }


### PR DESCRIPTION
## Problem

The footer status indicator's `setInterval` captures `ctx` from `session_start`. When pi replaces the session (`newSession`/`fork`/`switchSession`), `ctx` becomes stale but the 10s interval keeps firing, crashing with:

```
Error: This extension ctx is stale after session replacement or reload.
    at ExtensionRunner.assertActive
    at get ui
    at Timeout.update [as _onTimeout] (biome-lsp/extensions/index.ts:591)
```

## Fix

Three layers of defense in the status indicator callback:

1. **`active` flag** — checked at the top of `update()`, prevents any work after cleanup
2. **try-catch** around `ctx.ui.setStatus()` — if the context is stale despite the flag, catches the error, sets `active = false`, and clears the interval
3. **Named shutdown handler** — sets `active = false` + clears the interval on `session_shutdown`

The interval now self-heals: if `session_shutdown` fires first, it stops cleanly. If a session replacement makes the context stale before shutdown fires, the try-catch catches it on the next tick and stops the interval.

## Testing

Reproduced by triggering a session replacement while the Biome daemon was running. Before fix: `uncaughtException` crash. After fix: status indicator stops gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session status tracking reliability with enhanced error handling and safer shutdown cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->