### PR TITLE
fix(biome-lsp): spawn native biome binary instead of npx.cmd to stop spawn EINVAL

### DIFF
--- a/packages/biome-lsp/extensions/biome-binary-resolver.ts
+++ b/packages/biome-lsp/extensions/biome-binary-resolver.ts
@@ -1,0 +1,96 @@
+/**
+ * Resolve the native Biome CLI binary for the current platform.
+ *
+ * WHY THIS EXISTS:
+ * Node.js >= 18.20 / 20.12 / 22+ (CVE-2024-27980 mitigation) SYNCHRONOUSLY
+ * throws `spawn EINVAL` when you spawn a `.cmd`/`.bat` file without
+ * `shell: true`. The old code did `spawn("npx.cmd", ["@biomejs/biome", ...])`,
+ * which failed at every session start on Windows + modern Node.
+ *
+ * FIX: resolve the real native executable shipped by the platform-specific
+ * `@biomejs/cli-*` package (a .exe / mach-o / elf, not a .cmd) and spawn
+ * THAT directly with `shell: false`. This is exactly what the official
+ * `@biomejs/biome/bin/biome` shim does internally.
+ */
+import { createRequire } from "node:module";
+import { arch, env, platform, release, version } from "node:process";
+import { execSync } from "node:child_process";
+
+// Resolve modules in the context of the `@biomejs/biome` package, where the
+// platform-specific `@biomejs/cli-*` packages live as siblings. This keeps
+// resolution correct regardless of where this resolver file is invoked from
+// (it is robust to hoisting and to being copied/transpiled).
+// Resolve modules in the context of the `@biomejs/biome` package, where the
+// platform-specific `@biomejs/cli-*` packages live as siblings. This keeps
+// resolution correct regardless of where this resolver file is invoked from.
+const require = createRequire(import.meta.url);
+const biomePkgJsonPath = require.resolve("@biomejs/biome/package.json");
+const requireFromBiome = createRequire(biomePkgJsonPath);
+
+const PLATFORMS = {
+	win32: {
+		x64: "@biomejs/cli-win32-x64/biome.exe",
+		arm64: "@biomejs/cli-win32-arm64/biome.exe",
+	},
+	darwin: {
+		x64: "@biomejs/cli-darwin-x64/biome",
+		arm64: "@biomejs/cli-darwin-arm64/biome",
+	},
+	linux: {
+		x64: "@biomejs/cli-linux-x64/biome",
+		arm64: "@biomejs/cli-linux-arm64/biome",
+	},
+	"linux-musl": {
+		x64: "@biomejs/cli-linux-x64-musl/biome",
+		arm64: "@biomejs/cli-linux-arm64-musl/biome",
+	},
+};
+
+function isMusl(): boolean {
+	let stderr: Buffer | string;
+	try {
+		stderr = execSync("ldd --version", { stdio: ["pipe", "pipe", "pipe"] });
+	} catch (err) {
+		stderr = (err as { stderr?: Buffer | string }).stderr ?? "";
+	}
+	return String(stderr).includes("musl");
+}
+
+/** Environment variables Biome expects when launched from an npm install. */
+export function getBiomeSpawnEnv(): NodeJS.ProcessEnv {
+	let packageManager: string | null = null;
+	const userAgent = env.npm_config_user_agent;
+	if (userAgent) packageManager = userAgent.split(" ")[0] ?? null;
+
+	return {
+		...env,
+		BIOME_DISTRIBUTION: "npm",
+		JS_RUNTIME_VERSION: version,
+		JS_RUNTIME_NAME: release.name,
+		...(packageManager != null ? { NODE_PACKAGE_MANAGER: packageManager } : {}),
+	};
+}
+
+/**
+ * Resolve the native Biome binary path for the current platform.
+ * Honours `BIOME_BINARY` like the upstream shim.
+ * Throws if no prebuilt binary is available for this platform.
+ */
+export function resolveBiomeBinary(): string {
+	const spec =
+		env.BIOME_BINARY ||
+		(platform === "linux" && isMusl()
+			? PLATFORMS["linux-musl"]?.[arch as "x64" | "arm64"]
+			: PLATFORMS[platform as keyof typeof PLATFORMS]?.[
+					arch as "x64" | "arm64"
+				]);
+
+	if (!spec) {
+		throw new Error(
+			`No prebuilt Biome binary for platform=${platform} arch=${arch}. ` +
+				"Set BIOME_BINARY to point at a local build.",
+		);
+	}
+
+	return requireFromBiome.resolve(spec);
+}

--- a/packages/biome-lsp/extensions/index.ts
+++ b/packages/biome-lsp/extensions/index.ts
@@ -30,6 +30,22 @@ import {
 	truncateHead,
 } from "@mariozechner/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
+import {
+	getBiomeSpawnEnv,
+	resolveBiomeBinary,
+} from "./biome-binary-resolver.ts";
+
+// ---------------------------------------------------------------------------
+// Resolve the native Biome binary (NOT npx.cmd)
+// ---------------------------------------------------------------------------
+// Node.js >= 18.20 / 20.12 / 22+ blocks spawning .cmd/.bat without shell:true
+// (CVE-2024-27980), throwing `spawn EINVAL`. So we resolve and spawn the real
+// native executable shipped by the platform-specific @biomejs/cli-* package.
+let biomeBinCache: string | null = null;
+function getBiomeBin(): string {
+	if (!biomeBinCache) biomeBinCache = resolveBiomeBinary();
+	return biomeBinCache;
+}
 
 // ---------------------------------------------------------------------------
 // File extensions Biome supports
@@ -74,13 +90,14 @@ class BiomeDaemon {
 	async start(cwd: string): Promise<void> {
 		if (this.proc) return;
 
-		const cmd = process.platform === "win32" ? "npx.cmd" : "npx";
-		const args = ["@biomejs/biome", "lsp-proxy"];
+		// Resolve the native binary up front. If it is missing we surface a clear
+		// error instead of a cryptic spawn EINVAL.
+		const bin = getBiomeBin();
 
-		this.proc = spawn(cmd, args, {
+		this.proc = spawn(bin, ["lsp-proxy"], {
 			cwd,
 			stdio: ["pipe", "pipe", "pipe"],
-			env: { ...process.env },
+			env: getBiomeSpawnEnv(),
 			windowsHide: true,
 			detached: false,
 		});
@@ -113,15 +130,14 @@ class BiomeDaemon {
 			});
 		}
 
-		// Give it a moment to initialize, then verify with a health check
+		// Give it a moment to initialize, then verify with a health check.
+		// Uses the native binary directly (no npx.cmd -> no EINVAL).
 		await new Promise((r) => setTimeout(r, 1500));
-
-		// Verify biome is available
 		try {
-			const cmd2 = process.platform === "win32" ? "npx.cmd" : "npx";
-			const version = spawn(cmd2, ["@biomejs/biome", "--version"], {
+			const version = spawn(bin, ["--version"], {
 				cwd,
 				stdio: "pipe",
+				env: getBiomeSpawnEnv(),
 				windowsHide: true,
 			});
 			await new Promise<void>((res, rej) => {
@@ -143,9 +159,9 @@ class BiomeDaemon {
 
 		// Try graceful shutdown via CLI
 		try {
-			const cmd = process.platform === "win32" ? "npx.cmd" : "npx";
-			const stop = spawn(cmd, ["@biomejs/biome", "stop"], {
+			const stop = spawn(getBiomeBin(), ["stop"], {
 				stdio: "pipe",
+				env: getBiomeSpawnEnv(),
 				windowsHide: true,
 			});
 			await new Promise<void>((res) => {
@@ -172,8 +188,7 @@ class BiomeDaemon {
 		options: { write?: boolean } = {},
 	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
 		return new Promise((resolve, reject) => {
-			const cmd = process.platform === "win32" ? "npx.cmd" : "npx";
-			const args = ["@biomejs/biome", command, ...targets];
+			const args = [command, ...targets];
 
 			if (this._ready) {
 				args.push("--use-server");
@@ -183,9 +198,9 @@ class BiomeDaemon {
 				args.push("--write");
 			}
 
-			const proc = spawn(cmd, args, {
+			const proc = spawn(getBiomeBin(), args, {
 				cwd,
-				env: { ...process.env },
+				env: getBiomeSpawnEnv(),
 				stdio: ["pipe", "pipe", "pipe"],
 				windowsHide: true,
 			});

--- a/packages/biome-lsp/extensions/index.ts
+++ b/packages/biome-lsp/extensions/index.ts
@@ -133,7 +133,16 @@ class BiomeDaemon {
 		// Give it a moment to initialize, then verify with a health check.
 		// Uses the native binary directly (no npx.cmd -> no EINVAL).
 		await new Promise((r) => setTimeout(r, 1500));
+
+		// Guard: if lsp-proxy already exited during the wait, do NOT mark ready.
+		// Otherwise runCommand() would add --use-server against a dead daemon.
+		const proxyAlive = () =>
+			this.proc != null && this.proc.exitCode === null && !this.proc.killed;
+
 		try {
+			if (!proxyAlive()) {
+				throw new Error("Biome lsp-proxy exited before readiness check");
+			}
 			const version = spawn(bin, ["--version"], {
 				cwd,
 				stdio: "pipe",
@@ -146,10 +155,11 @@ class BiomeDaemon {
 				);
 				version.on("error", rej);
 			});
-			this._ready = true;
+			this._ready = proxyAlive();
 		} catch {
-			// Daemon may still work even if version check fails
-			this._ready = true;
+			// Daemon may still work even if the version check fails, but only if the
+			// proxy is actually still alive.
+			this._ready = proxyAlive();
 		}
 	}
 


### PR DESCRIPTION
## What

Stop spawning `npx.cmd @biomejs/biome ...` and instead resolve + spawn the **platform-specific native Biome executable** (`@biomejs/cli-win32-x64/biome.exe`, `@biomejs/cli-darwin-arm64/biome`, etc.) directly with `shell: false`.

Adds `packages/biome-lsp/extensions/biome-binary-resolver.ts` and updates all four spawn sites in `packages/biome-lsp/extensions/index.ts` (`start`, `--version` health-check, `stop`, `runCommand`).

## Why

On Node.js **≥ 18.20 / 20.12 / 22+**, the mitigation for **CVE-2024-27980** makes Node throw `spawn EINVAL` synchronously whenever a `.cmd`/`.bat` file is spawned without `shell: true`. The extension does exactly that at every `session_start`:

```ts
const cmd = process.platform === "win32" ? "npx.cmd" : "npx";
this.proc = spawn(cmd, ["@biomejs/biome", "lsp-proxy"], { /* shell: false (default) */ });
```

So on Windows + modern Node, the daemon **never starts**, every session shows:

```
Warning: Biome daemon failed to start: spawn EINVAL
```

…and the auto-lint-after-edit feature, `--use-server` fast path, and the `/biome start` command are all silently dead.

## How

- **Resolve the real binary**, not the `.cmd` shim. `@biomejs/biome` ships prebuilt native binaries in per-platform optional-dependency packages (`@biomejs/cli-win32-x64`, `@biomejs/cli-darwin-arm64`, …). The new `biome-binary-resolver.ts` resolves the right one via `require.resolve()` in the module context of `@biomejs/biome/package.json`, honouring `BIOME_BINARY` and detecting musl on Linux — i.e. a faithful port of the official `@biomejs/biome/bin/biome` shim.
- **Spawn with `shell: false`** (the default). Native executables are not subject to the CVE mitigation, so no EINVAL.
- `getBiomeSpawnEnv()` sets the env vars Biome expects when launched from an npm install (`BIOME_DISTRIBUTION`, `JS_RUNTIME_VERSION`, `NODE_PACKAGE_MANAGER`), matching the upstream shim.
- Chose native-binary resolution over the `shell: true` workaround because it also removes the `npx` startup overhead (daemon is up faster) and avoids `DEP0190` deprecation warnings about unescaped args.

## Testing

Reproduced and verified on **Windows 11 x64, Node v24.14.0** (the failing combo):

| Step | Result |
| --- | --- |
| `spawn("npx.cmd", ["@biomejs/biome","--version"], {shell:false})` (old code path) | `Error: spawn EINVAL` (errno -4071) — **reproduced** |
| `spawn(resolveBiomeBinary(), ["--version"], {shell:false})` (new code path) | exit 0, `Version: 2.5.0` — **fixed, no EINVAL** |
| jiti compile-load of patched `index.ts` (pi's extension loader) | transpiles cleanly |

Verified all four spawn sites now call `spawn(getBiomeBin()/bin, [...])` with no remaining `npx` references in code (only in comments). Cross-platform matrix in `biome-binary-resolver.ts` covers win32/darwin/linux × x64/arm64 (+ musl), mirroring `@biomejs/biome`'s own support.

## Checklist

- [x] Tests added/updated — none exist in the package today; manual reproduction table above. Happy to add a Vitest/Node test if the maintainer wants one.
- [x] Documentation updated — inline comments explain the CVE root cause at the spawn sites.
- [x] No breaking changes — same CLI subcommands invoked (`lsp-proxy`, `--version`, `stop`, `check`/`lint`/`format` with `--use-server`/`--write`); only the launcher changes from `npx @biomejs/biome` to the native binary. Behaviour identical on macOS/Linux (they already used non-`.cmd` launchers); this fixes Windows and removes `npx` overhead everywhere.

---

**Heads up for the maintainer:** this repo currently has no `LICENSE` file. If you'd like to merge third-party contributions cleanly, consider adding one (e.g. MIT/Apache-2.0) — happy to include that in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Biome LSP startup by resolving and launching the correct prebuilt native binary for the current platform/architecture.
  * Added Linux runtime detection to select the appropriate Biome binary environment.

* **Refactor**
  * Updated process spawning to use resolved native binaries directly (instead of running through npm tooling), including improved daemon start/stop and readiness checks.
  * Standardized command argument handling and environment setup for Biome execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->