### PR TITLE
fix(tokens-per-second): guard stale ctx in message_end cleanup timer

### DIFF
--- a/packages/tokens-per-second/extensions/index.ts
+++ b/packages/tokens-per-second/extensions/index.ts
@@ -138,9 +138,17 @@ export default function (pi: ExtensionAPI) {
 		const rate = theme.fg("success", `(${finalTps} t/s)`);
 		ctx.ui.setStatus(STATUS_KEY, `${icon} ${summary} ${rate}`);
 
-		// Clear after 15 seconds
+		// Clear after 15 seconds. The captured ctx goes stale if the session is
+		// replaced (new_session / switch / fork / reload) before the timer fires;
+		// touching ctx.ui then throws, and an uncaught throw in a timer callback
+		// crashes the whole pi process.
 		setTimeout(() => {
-			ctx.ui.setStatus(STATUS_KEY, "");
+			try {
+				ctx.ui.setStatus(STATUS_KEY, "");
+			} catch {
+				// stale ctx: the session was replaced in the meantime, and the
+				// replacement owns its own status line
+			}
 		}, 15000);
 	});
 


### PR DESCRIPTION
## Problem

The `message_end` handler schedules a 15s `setTimeout` that clears the status line. The callback captures the event's `ctx`.

If the session is replaced before the timer fires (`new_session`, session switch, fork, reload), the core invalidates that ctx. When the timer fires, `ctx.ui.setStatus(...)` throws, and the uncaught throw inside the timer callback **crashes the whole pi process**.

Repro:
1. Send a message (the cleanup timer is scheduled on `message_end`).
2. Replace the session within 15 seconds (e.g. delete the active session from the UI).
3. pi crashes when the timer fires.

## Fix

Wrap the status clear in `try/catch`: a stale ctx means the session was replaced and the replacement owns its own status line, so there is nothing to clear.

Verified locally: no crash after deleting/replacing the session while the timer is pending; the status line still clears normally after 15s in an ordinary session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the application from crashing when a delayed status update runs after switching, forking, reloading, or starting a new session.
  - Stale status updates are now safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->